### PR TITLE
2captcha integration

### DIFF
--- a/src/captcha/2captcha.ts
+++ b/src/captcha/2captcha.ts
@@ -1,6 +1,7 @@
 import got from 'got'
 import { sleep } from '../utils'
 import {CaptchaType, SolverOptions} from "./index";
+import log from "../log";
 
 const tcRetryPause = 5000
 const tcInitialPause = 15000
@@ -9,33 +10,44 @@ const tcUrlApiResult = 'https://2captcha.com/res.php'
 
 
 export default async function solve({ url, sitekey, type }: SolverOptions): Promise<string> {
+  log.info('2Captcha: Starting to resolve URL: ' + url)
   if (type != 'hCaptcha')
     throw 'Unsupported captcha type: ' + type
 
   const apikey = process.env.TWOCAPTCHA_APIKEY
 
   const reqUrl = tcUrlApiReq + '?key=' + apikey + '&method=hcaptcha' + '&sitekey=' + sitekey + '&pageurl=' + url + '&json=1'
+  log.info('2Captcha: Sending challenge: ' + reqUrl)
   const resp = await got(reqUrl)
+  log.info('2Captcha: Response: ' + resp.body)
 
-  console.log(resp.body);
   const content = JSON.parse(resp.body)
 
   if (content.status != 1)
-    throw '2Captcha returned error: ' + content.request
+    throw Error('2Captcha returned error: ' + content.request)
 
+  log.info('2Captcha: Initial pause: ' + tcInitialPause + ' ms')
   await sleep(tcInitialPause)
 
   const respUrl = tcUrlApiResult + '?key=' + apikey + '&id=' + content.request + '&json=1&action=get'
   while(true) {
+    log.info('2Captcha: Querying solution URL: ' + respUrl)
     const result = await got(respUrl)
+    log.info('2Captcha: Response: ' + result.body)
 
     const solution = JSON.parse(result.body)
 
-    if(solution.request === 'CAPCHA_NOT_READY') {
-      await sleep(tcRetryPause)
+    if (solution.status == 0) {
+      return solution.request
     }
     else {
-      return solution.request
+      if(solution.request === 'CAPCHA_NOT_READY') {
+        log.info('2Captcha: Solution not ready yet. Retrying soon...')
+        await sleep(tcRetryPause)
+      }
+      else {
+        throw Error('Captcha error: ' + solution.request)
+      }
     }
   }
 }

--- a/src/captcha/2captcha.ts
+++ b/src/captcha/2captcha.ts
@@ -1,0 +1,41 @@
+import got from 'got'
+import { sleep } from '../utils'
+import {CaptchaType, SolverOptions} from "./index";
+
+const tcRetryPause = 5000
+const tcInitialPause = 15000
+const tcUrlApiReq = 'https://2captcha.com/in.php'
+const tcUrlApiResult = 'https://2captcha.com/res.php'
+
+
+export default async function solve({ url, sitekey, type }: SolverOptions): Promise<string> {
+  if (type != 'hCaptcha')
+    throw 'Unsupported captcha type: ' + type
+
+  const apikey = process.env.TWOCAPTCHA_APIKEY
+
+  const reqUrl = tcUrlApiReq + '?key=' + apikey + '&method=hcaptcha' + '&sitekey=' + sitekey + '&pageurl=' + url + '&json=1'
+  const resp = await got(reqUrl)
+
+  console.log(resp.body);
+  const content = JSON.parse(resp.body)
+
+  if (content.status != 1)
+    throw '2Captcha returned error: ' + content.request
+
+  await sleep(tcInitialPause)
+
+  const respUrl = tcUrlApiResult + '?key=' + apikey + '&id=' + content.request + '&json=1&action=get'
+  while(true) {
+    const result = await got(respUrl)
+
+    const solution = JSON.parse(result.body)
+
+    if(solution.request === 'CAPCHA_NOT_READY') {
+      await sleep(tcRetryPause)
+    }
+    else {
+      return solution.request
+    }
+  }
+}


### PR DESCRIPTION
Hi! Well, this isn't a finished and ready-to-integrate PR but it might become one at some point (hopefully).

I tried to implement a solver for 2captcha by using the solver interface as provided by CloudProxy:
```typescript
export default async function solve({ url, sitekey, type }: SolverOptions): Promise<string> {
...
}
```
Also according to 2captcha API documentation:
https://2captcha.com/2captcha-api#solving_hcaptcha

It basically needs two parameters: `url` and `sitekey`. Both are provided in the CloudProxy interface above (good!).

There are some things I do not fully understand. Maybe you could help me out there.

2captcha expects to get the `sitekey` passed to their API. When testing on the site `https://dreamsfriend.com` then the returned HTML did not contain `data-sitekey` (while it still looked like a captcha page according to the HTML). This is the HTML logged by CloudProxy:
https://pastebin.com/dYMh570g

Also CloudProxy does only try to parse `data-sitekey` from non-HCaptcha-sites but I hacked it to make it still try to parse by modifying this condition:
```typescript
          if (captchaType != 'hCaptcha' && process.env.CAPTCHA_SOLVER != 'hcaptcha-solver') {
```


Also 2captcha expects the URL of the page passed (of course). But when the 2captha-servers are requesting that URL then I suspect it won't neccessarily display a captcha since CF seems to decide if a captcha is even presented. 

So basically I am unsure if I am on the right track there...