### PR TITLE
challenge selector for forms without css class

### DIFF
--- a/src/routes.ts
+++ b/src/routes.ts
@@ -66,7 +66,7 @@ type OverridesProps =
   'postData' |
   'headers'
 
-const CHALLENGE_SELECTORS = ['.ray_id', '.attack-box', '#trk_jschal_js']
+const CHALLENGE_SELECTORS = ['#trk_jschal_js', '.ray_id', '.attack-box']
 const TOKEN_INPUT_NAMES = ['g-recaptcha-response', 'h-captcha-response']
 
 async function resolveChallenge(ctx: RequestContext, { url, maxTimeout, proxy, download }: BaseRequestAPICall, page: Page): Promise<ChallengeResolutionT | void> {

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -66,7 +66,7 @@ type OverridesProps =
   'postData' |
   'headers'
 
-const CHALLENGE_SELECTORS = ['.ray_id', '.attack-box']
+const CHALLENGE_SELECTORS = ['.ray_id', '.attack-box', '#trk_jschal_js']
 const TOKEN_INPUT_NAMES = ['g-recaptcha-response', 'h-captcha-response']
 
 async function resolveChallenge(ctx: RequestContext, { url, maxTimeout, proxy, download }: BaseRequestAPICall, page: Page): Promise<ChallengeResolutionT | void> {


### PR DESCRIPTION
This should fix https://github.com/NoahCardoza/CloudProxy/issues/24 - some challenge forms don't seem to have ray_id or attack-box CSS selectors, so I added another one for a transparent gif that seems to be present in most CF challenge forms.