### PR TITLE
Implement multiarch auto build

### DIFF
--- a/.github/workflows/autotag.yml
+++ b/.github/workflows/autotag.yml
@@ -1,0 +1,20 @@
+name: autotag
+
+on:
+  push:
+    branches:
+      - "master"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Auto Tag
+        uses: Klemensas/action-autotag@stable
+        with:
+          GITHUB_TOKEN: "${{ secrets.GH_PAT }}"
+          tag_prefix: "v"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,6 @@ name: build
 
 on:
   push:
-    branches:
-      - '**'
     tags:
       - 'v*.*.*'
 
@@ -22,7 +20,7 @@ jobs:
         id: docker_meta
         uses: crazy-max/ghaction-docker-meta@v1
         with:
-          images: ghcr.io/${{ env.REPOSITORY }}
+          images: ${{ env.REPOSITORY }},ghcr.io/${{ env.REPOSITORY }}
           tag-sha: true
       -
         name: Set up QEMU
@@ -31,12 +29,18 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       -
+        name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
         name: Login to GitHub Container Registry
         uses: docker/login-action@v1 
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
+          password: ${{ secrets.GH_PAT }}
       -
         name: Build and push
         uses: docker/build-push-action@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,49 @@
+name: build
+
+on:
+  push:
+    branches:
+      - '**'
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Downcase repo
+        run: echo REPOSITORY=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
+      -
+        name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          images: ghcr.io/${{ env.REPOSITORY }}
+          tag-sha: true
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v1 
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm/v7,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,32 @@
-FROM node:10-jessie
+FROM --platform=${TARGETPLATFORM:-linux/amd64} node:alpine
 
-RUN apt-get update -y && \
-    apt-get install -y gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget libgbm1 && \
-    apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/*
-RUN mkdir -p /home/node/cloudproxy && chown -R node:node /home/node/cloudproxy
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN printf "I am running on ${BUILDPLATFORM:-linux/amd64}, building for ${TARGETPLATFORM:-linux/amd64}\n$(uname -a)\n"
+
+# Install packages
+RUN apk add --no-cache \
+      chromium \
+      nss \
+      freetype \
+      freetype-dev \
+      harfbuzz \
+      ca-certificates \
+      ttf-freefont \
+      nodejs \
+      npm \
+      yarn
+
+# Tell Puppeteer to skip installing Chrome. We'll be using the installed package.
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
+    PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
+
+RUN mkdir -p /home/node/cloudproxy
 WORKDIR /home/node/cloudproxy
-
-COPY package*.json ./
+COPY . .
+RUN chown -R node:node /home/node/cloudproxy
 USER node
 RUN PUPPETEER_PRODUCT=chrome npm install
-COPY --chown=node:node . .
 
 ENV LOG_LEVEL=info
 ENV LOG_HTML=


### PR DESCRIPTION
Hi !

Based on https://github.com/Jackett/Jackett/issues/9029#issuecomment-728315266 (Thanks @errtus !) and some GoogleSearchFu ™️, I was able to automate building CloudProxy on the 3 platforms (x64, arm32, arm64) successfully using GitHub actions and hosting the resulting container on GitHub's Container Repository (ghcr.io) :
![image](https://user-images.githubusercontent.com/524706/99395785-39f45a80-28e1-11eb-9e0e-46515ff669ff.png)

Now to enable it on your repo, you will need to :
1. [Enable improved container support](https://docs.github.com/en/free-pro-team@latest/packages/getting-started-with-github-container-registry/enabling-improved-container-support).
2. [Create a personal access token](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token) and add it as a secret in your repository to be able to push to ghcr.io.
3. Merge this PR.
    This will trigger a build, with tags set as the branch name (ie: `master`). To generate new builds and get a `latest` label, you will have to create a release (by git tagging or making a release on GitHub) with a version like `v0.0.1`. (More info [here](https://stackoverflow.com/questions/18216991/create-a-tag-in-a-github-repository)).
4. [Make the package repository public](https://docs.github.com/en/free-pro-team@latest/packages/publishing-and-managing-packages/publishing-a-package), so users can see and use it.
5. Once at least one release exists, it'll build an image with the `latest` tag and users can use it via `docker pull ghcr.io/noahcardoza/cloudproxy`, which should pull the matching architecture. (More info about the tagging available in the [action's docs](https://github.com/crazy-max/ghaction-docker-meta))
6. Profit ! 🎉 

Hope this helps :)
