### PR TITLE
Add dumb-init to prevent zombie process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 RUN printf "I am running on ${BUILDPLATFORM:-linux/amd64}, building for ${TARGETPLATFORM:-linux/amd64}\n$(uname -a)\n"
 
-# Install Chromium and remove all locales but en-US
-RUN apk add --no-cache chromium && \
+# Install Chromium and dumb-init and remove all locales but en-US
+RUN apk add --no-cache chromium dumb-init && \
     find /usr/lib/chromium/locales -type f ! -name 'en-US.*' -delete
 
 # Copy CloudProxy code
@@ -26,4 +26,5 @@ RUN npm install && \
     npm prune --production
 
 EXPOSE 8191
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["npm", "start"]


### PR DESCRIPTION
This fix having zombie chrome process in the docker image.

For more info:
https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#tips
https://github.com/puppeteer/puppeteer/issues/615#issuecomment-357193250
https://github.com/puppeteer/puppeteer/issues/1825