### PR TITLE
Fix applying custom cookies error and 'Failed to open browser' bug

### DIFF
--- a/src/routes.ts
+++ b/src/routes.ts
@@ -118,7 +118,14 @@ async function interceptResponse(page: Page, callback: (payload: ChallengeResolu
   });
 }
 
-async function resolveChallenge(ctx: RequestContext, { url, maxTimeout, proxy, download, returnOnlyCookies }: BaseRequestAPICall, page: Page): Promise<ChallengeResolutionT | void> {
+async function resolveChallenge(ctx: RequestContext, {
+  url,
+  maxTimeout,
+  cookies,
+  proxy,
+  download,
+  returnOnlyCookies
+}: BaseRequestAPICall, page: Page): Promise<ChallengeResolutionT | void> {
   maxTimeout = maxTimeout || 60000
   let status = 'ok'
   let message = ''
@@ -129,6 +136,10 @@ async function resolveChallenge(ctx: RequestContext, { url, maxTimeout, proxy, d
 
   log.debug(`Navigating to... ${url}`)
   let response = await page.goto(url, { waitUntil: 'domcontentloaded' })
+  if (cookies) {
+    log.debug(`Setting custom cookies: ${JSON.stringify(cookies, null, 2)}`,)
+    await page.setCookie(...cookies)
+  }
 
   // look for challenge
   if (response.headers().server.startsWith('cloudflare')) {
@@ -344,10 +355,10 @@ async function setupPage(ctx: RequestContext, params: BaseRequestAPICall, browse
     overrideResolvers.headers = request => Object.assign(request.headers(), headers)
   }
 
-  if (cookies) {
-    log.debug(`Setting custom cookies: ${JSON.stringify(cookies, null, 2)}`,)
-    await page.setCookie(...cookies)
-  }
+  // if (cookies) {
+  //   log.debug(`Setting custom cookies: ${JSON.stringify(cookies, null, 2)}`,)
+  //   await page.setCookie(...cookies)
+  // }
 
   // if any keys have been set on the object
   if (Object.keys(overrideResolvers).length > 0) {

--- a/src/session.ts
+++ b/src/session.ts
@@ -80,15 +80,17 @@ export default {
     let launchTries = 3
     let browser;
 
-    while (0 <= launchTries--) {
+    while (0 <= launchTries) {
       try {
         browser = await puppeteer.launch(puppeteerOptions)
         break
       } catch (e) {
-        if (e.message !== 'Failed to launch the browser process!')
-          throw e
+        log.error('puppeteer.launch error', e)
+        // if (e.message !== 'Failed to launch the browser process!')
+        //   throw e
         log.warn('Failed to open browser, trying again...')
       }
+      launchTries--
     }
 
     if (!browser) { throw Error(`Failed to lanch browser 3 times in a row.`) }


### PR DESCRIPTION
Adding a custom cookie to the request didn't work. Also, sometimes the application crashed with an error 'Failed to open browser'